### PR TITLE
remove concat_idents macro (causes build failures)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(concat_idents)]
 pub use acmd_proc_macros::*;
 
 use smash::lua2cpp::{L2CAgentBase, L2CFighterCommon, L2CFighterBase};


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/142704

doesn't seem to be used anywhere. as mentioned in title, the usage of this causes builds to fail